### PR TITLE
Add Rate Limiting and API Documentation

### DIFF
--- a/src/main/java/io/github/johneliud/letsplay/config/OpenAPIConfig.java
+++ b/src/main/java/io/github/johneliud/letsplay/config/OpenAPIConfig.java
@@ -1,0 +1,24 @@
+//package io.github.johneliud.letsplay.config;
+//
+//
+//import io.swagger.v3.oas.models.OpenAPI;
+//import io.swagger.v3.oas.models.info.Info;
+//import io.swagger.v3.oas.models.servers.Server;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//import java.util.List;
+//
+//@Configuration
+//public class OpenAPIConfig {
+//    @Bean
+//    public OpenAPI defineOpenAPI() {
+//        Server server = new Server();
+//        server.setUrl("http://localhost:8080");
+//        server.setDescription("Local development server");
+//
+//        Info information = new Info().title("Let's Play API").version("1.0").description("A RESTful CRUD API called lets-play, built using Spring Boot with MongoDB. The system will manage users and products, allowing operations such as creating, reading, updating, and deleting both entities.");
+//
+//        return new OpenAPI().info(information).servers(List.of(server));
+//    }
+//}

--- a/src/main/java/io/github/johneliud/letsplay/config/RateLimitConfig.java
+++ b/src/main/java/io/github/johneliud/letsplay/config/RateLimitConfig.java
@@ -1,0 +1,14 @@
+package io.github.johneliud.letsplay.config;
+
+import io.github.johneliud.letsplay.ratelimit.RateLimitService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RateLimitConfig {
+
+    @Bean
+    public RateLimitService rateLimitService() {
+        return new RateLimitService();
+    }
+}

--- a/src/main/java/io/github/johneliud/letsplay/config/SecurityConfig.java
+++ b/src/main/java/io/github/johneliud/letsplay/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package io.github.johneliud.letsplay.config;
 
+import io.github.johneliud.letsplay.ratelimit.RateLimitFilter;
 import io.github.johneliud.letsplay.security.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +33,9 @@ public class SecurityConfig {
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Autowired
+    private RateLimitFilter rateLimitFilter;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -53,6 +57,7 @@ public class SecurityConfig {
                         .requestMatchers("/users/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/io/github/johneliud/letsplay/ratelimit/RateLimitFilter.java
+++ b/src/main/java/io/github/johneliud/letsplay/ratelimit/RateLimitFilter.java
@@ -1,0 +1,62 @@
+package io.github.johneliud.letsplay.ratelimit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private RateLimitService rateLimitService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String clientId = getClientId(request);
+        String endpoint = request.getRequestURI();
+
+        if (!rateLimitService.isAllowed(clientId, endpoint)) {
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write("""
+                    {
+                        "timestamp": "%s",
+                        "status": 429,
+                        "error": "Too Many Requests",
+                        "message": "Rate limit exceeded. Try again later.",
+                        "path": "%s"
+                    }
+                    """.formatted(java.time.LocalDateTime.now(), endpoint));
+            return;
+        }
+
+        // Rate limit headers
+        long remaining = rateLimitService.getRemainingTokens(clientId, endpoint);
+        response.setHeader("X-RateLimit-Remaining", String.valueOf(remaining));
+        response.setHeader("X-RateLimit-Limit", getLimit(endpoint));
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getClientId(HttpServletRequest request) {
+        // Use IP address as a client identifier
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private String getLimit(String endpoint) {
+        return endpoint.startsWith("/auth/") ? "10" : "100";
+    }
+}

--- a/src/main/java/io/github/johneliud/letsplay/ratelimit/RateLimitService.java
+++ b/src/main/java/io/github/johneliud/letsplay/ratelimit/RateLimitService.java
@@ -1,0 +1,48 @@
+package io.github.johneliud.letsplay.ratelimit;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * Default: 100 requests per hour (0.028 tokens per second)
+ *
+ * Auth endpoints: 10 requests per minute (0.167 tokens per second)
+ * */
+public class RateLimitService {
+    private final ConcurrentHashMap<String, TokenBucket> buckets = new ConcurrentHashMap<>();
+
+    private static final long DEFAULT_CAPACITY = 100;
+    private static final double DEFAULT_REFILL_RATE = 100.0 / 3600.0;
+
+    private static final long AUTH_CAPACITY = 10;
+    private static final double AUTH_REFILL_RATE = 10.0 / 60.0;
+
+    public boolean isAllowed(String clientId, String endpoint) {
+        String key = clientId + ":" + getEndpointGroup(endpoint);
+        TokenBucket bucket = buckets.computeIfAbsent(key, k -> createBucket(endpoint));
+        return bucket.tryConsume(1);
+    }
+
+    public long getRemainingTokens(String clientId, String endpoint) {
+        String key = clientId + ":" + getEndpointGroup(endpoint);
+        TokenBucket bucket = buckets.get(key);
+        return bucket != null ? bucket.getAvailableTokens() : getCapacity(endpoint);
+    }
+
+    private TokenBucket createBucket(String endpoint) {
+        if (endpoint.startsWith("/auth/")) {
+            return new TokenBucket(AUTH_CAPACITY, AUTH_REFILL_RATE);
+        }
+        return new TokenBucket(DEFAULT_CAPACITY, DEFAULT_REFILL_RATE);
+    }
+
+    private String getEndpointGroup(String endpoint) {
+        if (endpoint.startsWith("/auth/")) return "auth";
+        if (endpoint.startsWith("/users")) return "users";
+        if (endpoint.startsWith("/products")) return "products";
+        return "default";
+    }
+
+    private long getCapacity(String endpoint) {
+        return endpoint.startsWith("/auth/") ? AUTH_CAPACITY : DEFAULT_CAPACITY;
+    }
+}

--- a/src/main/java/io/github/johneliud/letsplay/ratelimit/TokenBucket.java
+++ b/src/main/java/io/github/johneliud/letsplay/ratelimit/TokenBucket.java
@@ -1,0 +1,42 @@
+package io.github.johneliud.letsplay.ratelimit;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TokenBucket {
+    private final long capacity;
+    private final double refillRate;
+    private final AtomicLong tokens;
+    private volatile long lastRefillTime;
+
+    public TokenBucket(long capacity, double refillRate) {
+        this.capacity = capacity;
+        this.refillRate = refillRate;
+        this.tokens = new AtomicLong(capacity);
+        this.lastRefillTime = Instant.now().getEpochSecond();
+    }
+
+    public synchronized boolean tryConsume(long tokensToConsume) {
+        refill();
+        long currentTokens = tokens.get();
+        if (currentTokens >= tokensToConsume) {
+            tokens.addAndGet(-tokensToConsume);
+            return true;
+        }
+        return false;
+    }
+
+    private void refill() {
+        long now = Instant.now().getEpochSecond();
+        double tokensToAdd = (now - lastRefillTime) * refillRate;
+        if (tokensToAdd > 0) {
+            tokens.set(Math.min(capacity, tokens.get() + (long) tokensToAdd));
+            lastRefillTime = now;
+        }
+    }
+
+    public long getAvailableTokens() {
+        refill();
+        return tokens.get();
+    }
+}


### PR DESCRIPTION
## Overview
Implements rate limiting with token bucket algorithm and adds OpenAPI configuration (commented out).

## Changes
- **Rate Limit Filter**: IP-based rate limiting with different limits per endpoint group
- **Token Bucket Algorithm**: Efficient rate limiting implementation
- **Security Integration**: Rate limit filter added before authentication
- **OpenAPI Config**: Commented-out OpenAPI/Swagger configuration for future use

## Rate Limit Configuration
- **Default**: 100 requests per hour (0.028 tokens/sec)
- **Auth Endpoints**: 10 requests per minute (0.167 tokens/sec) to prevent brute force
- **Headers**: `X-RateLimit-Remaining` and `X-RateLimit-Limit` in responses
- **Response**: 429 status with JSON error when limit exceeded

## Key Details
- **Client Identification**: Uses IP address, supports `X-Forwarded-For` header
- **Endpoint Groups**: auth, users, products, default
- **Filter Order**: Rate limit check occurs before JWT authentication
- **Thread Safety**: ConcurrentHashMap and AtomicLong for thread-safe operations

## Testing Notes
- Test rate limiting by making rapid requests to auth endpoints
- Verify rate limit headers in responses
- Check 429 error response format
- Test different IP addresses for separate rate limits